### PR TITLE
feat/image-create

### DIFF
--- a/src/shared/components/Editor/index.tsx
+++ b/src/shared/components/Editor/index.tsx
@@ -9,7 +9,7 @@ const Editor = () => {
         <Button type="back" />
         <S.ItemContainer>
           <ProjectInputItem type="프로젝트 제목" />
-          <ProjectInputItem type="이미지 삽입" isBottom={true} />
+          <ProjectInputItem type="이미지 삽입" />
           <ProjectInputItem type="프로젝트 기간" />
           <ProjectInputItem type="프로젝트 설명" />
           <ProjectInputItem type="팀원 테이블" />

--- a/src/shared/components/ImageCreateInput/index.tsx
+++ b/src/shared/components/ImageCreateInput/index.tsx
@@ -9,6 +9,12 @@ const ImageCreateInput = () => {
     const { files } = event.target;
     if (files && files.length > 0) {
       const fileName = files[0].name;
+
+      /** 이미지 파일 유효성 검사 */
+      const extension = fileName.split('.').pop();
+      if (!extension || !['jpg', 'png', 'jpeg'].includes(extension))
+        return alert('이미지 타입이 아닙니다.');
+
       setImageList((prevImageList) => [...prevImageList, fileName]);
     }
   };

--- a/src/shared/components/ImageCreateInput/index.tsx
+++ b/src/shared/components/ImageCreateInput/index.tsx
@@ -1,0 +1,46 @@
+import { ChangeEvent, useState } from 'react';
+import * as S from './style';
+import UploadItem from '../common/UploadItem';
+
+const ImageCreateInput = () => {
+  const [imageList, setImageList] = useState<string[]>([]);
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { files } = event.target;
+    if (files && files.length > 0) {
+      const fileName = files[0].name;
+      setImageList((prevImageList) => [...prevImageList, fileName]);
+    }
+  };
+
+  const handleItemDelete = (index: number) => {
+    return () => {
+      const newList = imageList.filter((_, i) => i !== index);
+      setImageList(newList);
+    };
+  };
+
+  return (
+    <>
+      <S.RelativeBox>
+        <S.Input type="text" placeholder="width를 입력하세요. (% 가능)" />
+        <S.Input type="text" placeholder="height를 입력하세요. (% 가능)" />
+        <S.FileButton htmlFor="input-file">추가</S.FileButton>
+        <S.FileHiddenButton
+          type="file"
+          id="input-file"
+          onChange={handleFileChange}
+        />
+      </S.RelativeBox>
+      {imageList.length > 0 && (
+        <S.BottomWrapper>
+          {imageList.map((list, index) => (
+            <UploadItem text={list} onClick={handleItemDelete(index)} />
+          ))}
+        </S.BottomWrapper>
+      )}
+    </>
+  );
+};
+
+export default ImageCreateInput;

--- a/src/shared/components/ImageCreateInput/style.ts
+++ b/src/shared/components/ImageCreateInput/style.ts
@@ -1,0 +1,71 @@
+import styled from 'styled-components';
+
+export const RelativeBox = styled.div`
+  display: flex;
+  gap: 1.6rem;
+  position: relative;
+  padding: 1.6rem;
+  width: 82.9rem;
+  height: 8.4rem;
+
+  background: ${(props) => props.theme.colors.lightgray};
+  border-radius: 0 0 1rem 1rem;
+`;
+
+export const Input = styled.input`
+  font-family: 'Pretendard';
+  font-size: 1.4rem;
+  box-shadow: none;
+  outline: none;
+  border: none;
+  appearance: none;
+
+  width: 71.3rem;
+  height: 5.2rem;
+
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.6rem 2.4rem 1.6rem 2rem;
+
+  &::placeholder {
+    font-family: 'Pretendard';
+    font-style: normal;
+    font-weight: 400;
+    font-size: 1.6rem;
+    color: ${(props) => props.theme.colors.gray};
+  }
+`;
+
+export const FileButton = styled.label`
+  cursor: pointer;
+  border: none;
+  outline: none;
+  background: ${(props) => props.theme.colors.lightblue};
+  border-radius: 1rem;
+  white-space: nowrap;
+
+  padding: 1.6rem 2rem;
+
+  font-weight: 700;
+  font-size: 1.6rem;
+
+  color: ${(props) => props.theme.colors.blue};
+`;
+
+export const FileHiddenButton = styled.input`
+  display: none;
+`;
+
+export const BottomWrapper = styled.div`
+  width: 82.9rem;
+  height: 6.8rem;
+
+  background: ${(props) => props.theme.colors.lightgray};
+  border-radius: 0 0 1rem 1rem;
+
+  padding: 1.6rem;
+  border-top: 0.1rem solid rgba(214, 216, 229, 1);
+
+  display: flex;
+  gap: 1.2rem;
+`;

--- a/src/shared/components/common/ProjectInputItem/index.tsx
+++ b/src/shared/components/common/ProjectInputItem/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 import * as S from './style';
-import TechStackInput from '../../TechStackInput';
-
 import { ProjectInputItemProps } from '@/shared/types/projectInputItem';
 import Button from '../Button';
+import TechStackInput from '../../TechStackInput';
 import TeamTableInput from '../../TeamTableInput';
+import ImageCreateInput from '../../ImageCreateInput';
 
 interface ItemScript {
   [key: string]: React.ReactNode;
@@ -40,15 +40,7 @@ const ITEM_SCRIPT: ItemScript = {
     />
   ),
   '팀원 테이블': <TeamTableInput />,
-  '이미지 삽입': (
-    <S.InputBox>
-      <S.InputContainer>
-        <S.Input type="text" placeholder="width를 입력하세요. (% 가능)" />
-        <S.Input type="text" placeholder="height를 입력하세요. (% 가능)" />{' '}
-        <Button />
-      </S.InputContainer>
-    </S.InputBox>
-  ),
+  '이미지 삽입': <ImageCreateInput />,
   '프로젝트 기간': (
     <S.InputBox>
       <S.InputContainer>
@@ -65,6 +57,7 @@ const ITEM_SCRIPT: ItemScript = {
     </S.InputBox>
   ),
 };
+
 const ProjectInputItem = ({
   type,
   isBottom = false,
@@ -78,7 +71,6 @@ const ProjectInputItem = ({
         </S.ButtonWrapper>
       </S.HeaderContainer>
       {ITEM_SCRIPT[type]}
-      {isBottom && <S.BottomWrapper></S.BottomWrapper>}
     </div>
   );
 };


### PR DESCRIPTION
### 💬 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
* [x] 기능 추가
* [ ] 기능 변경
* [ ] 기능 삭제
* [ ] 디자인 수정
* [ ] 버그 수정
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌵 반영 브랜치
`feat/image-create -> dev`

### 🔎 작업 내용
#### 추가 버튼 클릭 시 폴더 불러오기
![image](https://github.com/Read-U/readyou-front/assets/81246338/88cf393c-c639-499c-a8b6-dca1546bb596)

#### 불러온 이미지 띄우기
![image](https://github.com/Read-U/readyou-front/assets/81246338/84a7bc03-453d-42e7-a215-faa9c2851cf0)


### ✨ 특이 사항/논의 사항
마찬가지로 아직 이미지의 width, height를 어떻게 넘겨야 하는지 몰라서, 일단 이미지 추가되는 부분까지 로직 구현했습니다!
