### PR TITLE
feat: defaultSetting 컴포넌트 구현

### DIFF
--- a/src/shared/components/DefaultSetting/index.tsx
+++ b/src/shared/components/DefaultSetting/index.tsx
@@ -1,0 +1,45 @@
+import * as S from './style';
+import Checkbox from '@/shared/components/common/Checkbox';
+import useCheckbox from '@/shared/hooks/useCheckbox';
+import Badge from '@/shared/components/common/Badge';
+import {
+  DEFAULT_CHECKED_ITEM,
+  DEFAULT_ITEM_LIST,
+} from '@/shared/constants/editor';
+
+const DefaultSetting = () => {
+  const { checkedList, handleCheckedElement } =
+    useCheckbox(DEFAULT_CHECKED_ITEM);
+
+  return (
+    <S.MarkdownTemplateList>
+      {DEFAULT_ITEM_LIST.map((markdownItem) => (
+        <S.MarkdownTemplateItem
+          key={markdownItem.id}
+          type={markdownItem.type}
+          checked={checkedList.some((item) => item.id === markdownItem.id)}
+          onClick={() => {
+            if (markdownItem.type !== 'required') {
+              handleCheckedElement(markdownItem);
+            }
+          }}
+        >
+          {markdownItem.type === 'required' ? (
+            <S.EmptyBox />
+          ) : (
+            <Checkbox
+              key={markdownItem.id}
+              defaultChecked={checkedList.some(
+                (item) => item.id === markdownItem.id,
+              )}
+            />
+          )}
+          <Badge type={markdownItem.type} />
+          <S.Title>{markdownItem.name}</S.Title>
+        </S.MarkdownTemplateItem>
+      ))}
+    </S.MarkdownTemplateList>
+  );
+};
+
+export default DefaultSetting;

--- a/src/shared/components/DefaultSetting/style.ts
+++ b/src/shared/components/DefaultSetting/style.ts
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+import { DefaultItemProps } from '@/shared/types/markdown';
+
+export const MarkdownTemplateList = styled.ul`
+  width: 100%;
+  padding: 2.4rem 2rem;
+  overflow-y: auto;
+`;
+
+export const MarkdownTemplateItem = styled.li<{
+  checked: boolean;
+  type: DefaultItemProps['type'];
+}>`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 60px;
+  padding: 1.2rem 2rem;
+  border-radius: 1rem;
+  background-color: ${(props) => {
+    const { type, checked, theme } = props;
+    switch (type) {
+      case 'required':
+        return theme.colors.gray;
+      case 'optional':
+        return checked ? theme.colors.lightblue : theme.colors.lightgray;
+      default:
+        return checked ? theme.colors.lightgray : theme.colors.lightgray;
+    }
+  }};
+  cursor: ${(props) => (props.type === 'optional' ? 'pointer' : 'default')};
+  transition: all 0.2s ease-in-out;
+
+  &:not(:last-child) {
+    margin-bottom: 10px;
+  }
+  > *:not(:last-child) {
+    margin-right: 16px;
+  }
+`;
+
+export const EmptyBox = styled.div`
+  width: 20px;
+`;
+
+export const Title = styled.p`
+  color: ${(props) => props.theme.colors.darknavy};
+  font-size: 1.6rem;
+`;


### PR DESCRIPTION
### 💬 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
* [x] 기능 추가
* [ ] 기능 변경
* [ ] 기능 삭제
* [ ] 디자인 수정
* [ ] 버그 수정
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌵 반영 브랜치
ex) feature/default-setting -> dev

### 🔎 작업 내용
- defaultSetting 컴포넌트 구현
<img width="710" alt="image" src="https://github.com/Read-U/readyou-front/assets/70426440/7a81e4a1-daaf-4a5b-98a2-3418648ad53d">

리하가 pages/editor/index 파일 관련된 코드 PR올려서 컴포넌트 작업에 대한 PR만 올립니다!
리하 PR 머지되면 editor 페이지에 조건부 렌더링으로 컴포넌트 표시하고 선택한 기본항목 값들 넘겨주는 로직 추가로 작성하면 될 것 같아요 !

아래 코드가 pages 에서 관리하고 props로 Editor 컴포넌트에 넘겨주면 될 것 같습니다 ㅎㅎ

```javascript
 const { checkedList, handleCheckedElement } =
    useCheckbox(DEFAULT_CHECKED_ITEM);

```
### ✨ 특이 사항/논의 사항
