### PR TITLE
design: 전체 복사 버튼 공통 버튼 컴포넌트로 변경 및 간격 수정

### DIFF
--- a/src/shared/components/Preview/CopyButton/index.tsx
+++ b/src/shared/components/Preview/CopyButton/index.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import * as S from './style';
 import 'github-markdown-css';
 import { useRecoilValue } from 'recoil';
 import { markdownState } from '@/recoil/states';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import useToast from '@/shared/hooks/useToast';
+import Button from '../../common/Button';
 const CopyButton = () => {
   const markdown = useRecoilValue(markdownState);
   const toast = useToast();
@@ -19,7 +19,7 @@ const CopyButton = () => {
         })
       }
     >
-      <S.CopyButton>전체 복사</S.CopyButton>
+      <Button type='copy'/>
     </CopyToClipboard>
   );
 };

--- a/src/shared/components/Preview/CopyButton/style.ts
+++ b/src/shared/components/Preview/CopyButton/style.ts
@@ -1,21 +1,21 @@
-import styled from 'styled-components';
+// import styled from 'styled-components';
 
-export const CopyButton = styled.div`
-  position: relative;
-  left: 0;
-  width: 9.9rem;
-  height: 5.2rem;
-  border-radius: 1rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 1.9rem;
-  cursor: pointer;
-  color: ${(props) => props.theme.colors.lightblue};
-  background: ${(props) => props.theme.colors.blue};
-  white-space: nowrap;
-  &:hover {
-    color: ${(props) => props.theme.colors.blue};
-    background: ${(props) => props.theme.colors.lightblue};
-  }
-`;
+// export const CopyButton = styled.div`
+//   position: relative;
+//   left: 0;
+//   width: 9.9rem;
+//   height: 5.2rem;
+//   border-radius: 1rem;
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
+//   font-size: 1.9rem;
+//   cursor: pointer;
+//   color: ${(props) => props.theme.colors.lightblue};
+//   background: ${(props) => props.theme.colors.blue};
+//   white-space: nowrap;
+//   &:hover {
+//     color: ${(props) => props.theme.colors.blue};
+//     background: ${(props) => props.theme.colors.lightblue};
+//   }
+// `;

--- a/src/shared/components/Preview/style.ts
+++ b/src/shared/components/Preview/style.ts
@@ -43,19 +43,19 @@ export const HeaderWrapper = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  margin-left: 1rem;
-  margin-top: 1rem;
+  gap: 0.8rem;
   font-size: 1.9rem;
 `;
 
 export const HeaderTitle = styled.div`
   position: relative;
   font-weight: bold;
+  font-size: 1.6rem;
 `;
 export const ToggleWrapper = styled.div`
   position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  font-size: 1.6rem;
 `;

--- a/src/shared/components/common/Button/index.tsx
+++ b/src/shared/components/common/Button/index.tsx
@@ -1,13 +1,14 @@
 import * as S from './style';
 
 interface ButtonType {
-  type?: 'back' | 'add';
+  type?: 'back' | 'add' |'copy';
   onClick?: () => void; // Added this line
 }
 
 const LABEL_TYPE = {
   add: '추가',
   back: '뒤로가기',
+  copy: '전체 복사',
 };
 
 const Button = ({ type = 'add', onClick }: ButtonType) => {

--- a/src/shared/components/common/Button/style.ts
+++ b/src/shared/components/common/Button/style.ts
@@ -5,7 +5,7 @@ export const Button = styled.button<{ type: string }>`
   border: none;
   outline: none;
   background: ${(props) =>
-    props.type === 'back'
+    props.type === 'back' || props.type === 'copy'
       ? props.theme.colors.blue
       : props.theme.colors.lightblue};
   border-radius: 1rem;
@@ -17,7 +17,7 @@ export const Button = styled.button<{ type: string }>`
   font-size: 1.6rem;
 
   color: ${(props) =>
-    props.type === 'back'
+    props.type === 'back' || props.type === 'copy'
       ? props.theme.colors.lightgray
       : props.theme.colors.blue};
 `;

--- a/src/shared/components/common/Toggle/style.ts
+++ b/src/shared/components/common/Toggle/style.ts
@@ -3,7 +3,7 @@ import { styled } from 'styled-components';
 export const ToggleWrapper = styled.div`
   display: flex;
   z-index: 0;
-  margin-left: 1rem;
+  margin-left: 0.8rem;
 `;
 
 export const CheckBox = styled.input`


### PR DESCRIPTION
### 💬 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
* [ ] 기능 추가
* [ ] 기능 변경
* [ ] 기능 삭제
* [x] 디자인 수정
* [ ] 버그 수정
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌵 반영 브랜치
`feat/editor -> dev`

### 🔎 작업 내용
Priview 컴포넌트의 '전체 복사' 버튼을 공통 버튼 컴포넌트로 변경하고
나머지 미세한 간격 피그마대로 재조정하였습니다!

### ✨ 특이 사항/논의 사항
