### PR TITLE
fix: 기존 iframe 방식은 리드미에 제한 되어 썸네일 링크 형식으로 변경

### DIFF
--- a/src/shared/components/TechStackInput/index.tsx
+++ b/src/shared/components/TechStackInput/index.tsx
@@ -117,17 +117,6 @@ const TechStackInput = ({ type, placeholder }: InputProps) => {
           }
         })}
       </S.BottomWrapper>
-      {/* {uploadList.length !== 0 && (
-        <S.BottomWrapper>
-          {uploadList?.map((list, idx) => (
-            <UploadItem
-              onClick={() => handleUploadItemDelete(idx, list)}
-              key={idx}
-              text={list}
-            />
-          ))}
-        </S.BottomWrapper>
-      )} */}
     </>
   );
 };

--- a/src/shared/components/UploadVideoInput/index.tsx
+++ b/src/shared/components/UploadVideoInput/index.tsx
@@ -14,7 +14,7 @@ interface UploadListType {
   markdown: string;
 }
 
-const regex = /\/embed\/([\w-]{11})/;
+const regex = /\/vi\/([A-Za-z0-9_-]{11})\//;
 
 const UploadVideoInput = ({ type, placeholder }: InputProps) => {
   const [value, setValue] = useState('');
@@ -48,7 +48,7 @@ const UploadVideoInput = ({ type, placeholder }: InputProps) => {
         throw new Error('유효하지 않은 링크입니다!');
       }
       const result = await res.json();
-      return result.iframe;
+      return result.videoId;
     } catch (error) {
       toast({
         message: '유효하지 않는 링크입니다!',
@@ -74,7 +74,12 @@ const UploadVideoInput = ({ type, placeholder }: InputProps) => {
     }
     const newMarkdown = markdown.map((item) => {
       if (item.name === 'video') {
-        return { ...item, detail: item.detail + `${validationResult}\n` };
+        return {
+          ...item,
+          detail:
+            item.detail +
+            `[![영상 썸네일 이미지](http://img.youtube.com/vi/${validationResult}/0.jpg)](https://youtu.be/${validationResult})\n`,
+        };
       }
       return item;
     });
@@ -86,7 +91,6 @@ const UploadVideoInput = ({ type, placeholder }: InputProps) => {
     ]);
     setValue('');
   };
-
   return (
     <>
       <S.RelativeBox>
@@ -101,9 +105,10 @@ const UploadVideoInput = ({ type, placeholder }: InputProps) => {
       <S.BottomWrapper>
         {markdown.map((item) => {
           if (item.name === 'video') {
-            const slice = item.detail.split('</iframe>');
-            slice.pop();
-            return slice?.map((list, idx) => {
+            console.log(item.detail);
+            const arr = item.detail.split('\n');
+            arr.pop();
+            return arr?.map((list, idx) => {
               const match = list.match(regex);
               if (match) {
                 return (


### PR DESCRIPTION
### 💬 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
* [ ] 기능 추가
* [ ] 기능 변경
* [ ] 기능 삭제
* [ ] 디자인 수정
* [x] 버그 수정
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌵 반영 브랜치
feat/upload-video -> dev

### 🔎 작업 내용
- 기존 iframe 방식은 마크다운 프리뷰에는 정상적으로 보이지만 깃허브 측에서는 iframe태그를 지원하지 않아서 문자열로 출력
- 해당 문제를 유뷰브 썸네일 이미지에 유튜브 링크 거는 방식으로 변경

### 논의사항
유튜브 썸네일 이미지를 클릭하면 영상 링크로 가는 방식인데 프리뷰로 봤을 때는 이미지인지 영상인지 구분이 안가서 텍스트를 넣거나? 조금 더 이게 영상으로 가는 링크라는걸 알려줘야 할 것 같은데 좋은 아이디어 있으시면 말씀해 주세요!!

### ✨ 영상

https://github.com/Read-U/readyou-front/assets/162881886/9dca8313-759e-4f4f-9f22-5e71d9b62fd1



